### PR TITLE
Disable signature helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Imba tooling for VSCode
 1. Install vsce package - npm install -g vsce
 2. run `vsce package` to create a .vsix file in your folder
 3. Go to Extension tab in vscode sidebar. Click on the ... in the top menu. Choose `Select from vsix...`. Find the .vsix file generated above.
+

--- a/server/src/main.imba
+++ b/server/src/main.imba
@@ -73,7 +73,7 @@ connection.onInitialize do |params|
 			# Tell the client that the server works in FULL text document sync mode
 			textDocumentSync: documents:syncKind,
 			completionProvider: false, # { resolveProvider: false, triggerCharacters: ['.', ':', '<', '"', '/', '@', '*'] },
-			signatureHelpProvider: { triggerCharacters: ['('] },
+			signatureHelpProvider: false, # { triggerCharacters: ['('] },
 			documentRangeFormattingProvider: false,
 			hoverProvider: false,
 			documentHighlightProvider: false,


### PR DESCRIPTION
Fixes #6 

Disable signature as the server could not find the signatures. Do not think this was supposed to be enabled yet as there are no `registerSignatureHelpProvider`.