### PR TITLE
add a vscode ignore file

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,7 @@
+.vscode/**
+client/node_modules/**
+*.swo
+*.swp
+*.vsix
+node_modules/**
+server/node_modules/**


### PR DESCRIPTION
Before this the packaged size is (3.53MB) see output below
```
➜ vsce package
This extension consists of 1341 files, out of which 554 are JavaScript files. For performance reasons, you should bundle your extension: https://aka.ms/vscode
-bundle-extension . You should also exclude unnecessary files by adding them to your .vscodeignore: https://aka.ms/vscode-vscodeignore
 DONE  Packaged: /Users/scanf/src/github.com/somebee/vscode-imba/imba-0.5.1.vsix (1341 files, 3.53MB)
```

After it's now (56.31KB)
```
➜ vsce package
 DONE  Packaged: /Users/scanf/src/github.com/somebee/vscode-imba/imba-0.5.1.vsix (25 files, 56.31KB)
```