### PR TITLE
syntaxes: remove includes from the matches

### DIFF
--- a/syntaxes/imba.tmLanguage
+++ b/syntaxes/imba.tmLanguage
@@ -493,7 +493,7 @@
                 <key>name</key>
                 <string>keyword.other.special.method.imba</string>
                 <key>match</key>
-                <string>\b(initialize|new|include|extend|raise|attr_reader|attr_writer|attr_accessor|attr|private|module_function|public|protected|prop|property)\b</string>
+                <string>\b(initialize|new|extend|raise|attr_reader|attr_writer|attr_accessor|attr|private|module_function|public|protected|prop|property)\b</string>
             </dict>
             <dict>
                 <key>name</key>
@@ -524,7 +524,7 @@
                 <key>name</key>
                 <string>accessor.method.special.imba</string>
                 <key>match</key>
-                <string>(\.)(new|include|extend)</string>
+                <string>(\.)(new|extend)</string>
                 <key>captures</key>
                 <dict>
                     <key>0</key>

--- a/syntaxes/imba.tmLanguage.json
+++ b/syntaxes/imba.tmLanguage.json
@@ -276,7 +276,7 @@
         },
         "contentName": "variable.parameter.function.imba"
     },{
-        "match": "\\b(initialize|new|include|extend|raise|private|public|protected|prop|property)\\b",
+        "match": "\\b(initialize|new|extend|raise|private|public|protected|prop|property)\\b",
         "name": "keyword.other.special.method.imba"
     },{
         "match": "\\b(log|setInterval|setTimeout|isNaN|clearInterval|clearTimeout)\\b",
@@ -292,7 +292,7 @@
             "1": {"name": "punctuation.access.ivar.imba"}
         }
     },{
-        "match": "(\\.)(new|include|extend)",
+        "match": "(\\.)(new|extend)",
         "name": "accessor.method.special.imba",
         "captures": {
             "0": { "name": "identifier.method.imba"},


### PR DESCRIPTION
As far as I can see it's not part of the syntax and I suspect it is a
copy / pasta issue.

Closes: #2 (Wrong 'includes' highlighting)