### PR TITLE
syntaxes: use the CSS captures

### DIFF
--- a/syntaxes/imba.tmLanguage.json
+++ b/syntaxes/imba.tmLanguage.json
@@ -114,14 +114,29 @@
     },{
         "name": "comment.block.imba",
         "end": "###(?:[ \t]*\n)",
-        "begin": "^[ \t]*###",
+        "begin": "^[ \t]*###\\S",
         "captures": {
             "0": {"name": "punctuation.definition.comment.imba"}
         }
     },{
         "match": "(?:^[ \t]+)?(#\\s).*$\n?",
         "name": "comment.line.imba"
-    },{
+    },
+    {
+        "patterns": [{"include": "source.css"}],
+        "begin": "^[ \t]*###\\scss",
+        "end": "###(?:[ \t]*\n)",
+        "beginCaptures": {
+            "0": {
+                "name": "punctuation.definition.string.begin.css"
+            }
+        },
+        "endCaptures": {
+            "0": {
+                "name": "punctuation.definition.string.end.css"
+            }
+        }
+     },{
         "begin": "'",
         "beginCaptures": {
             "0": {"name": "punctuation.definition.string.begin.imba"}


### PR DESCRIPTION
This looks mostly fine but there are two issues. I had to make a change
to the comment block so it would not interfere. Note the `\S` appended.
The other thing is that we are not colorizing the `###`.

Regardless I think this basic support would let me use Visual Studio
Code more for Imba. Also these can be resolved better when we revamp the
language server support.